### PR TITLE
Don't package include files

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -44,3 +44,5 @@ export PATH="$TOP/vendor/make:$PATH"
 build skalibs
 build execline
 build s6
+
+rm -rf $dst/include


### PR DESCRIPTION
s6 won't install in a pypy virtualenv: 
```
error: could not create '/nail/home/drolando/pg/s6-setuptools/env/include/s6': Permission denied
```

The problem is that env/include is linked to pypy's include folder:
```bash
>>  ll env
total 28
drwxr-xr-x 2 drolando users 4096 2016-12-27 12:40 bin/
lrwxrwxrwx 1 drolando users   12 2016-12-27 12:34 include -> /usr/include/
drwxr-xr-x 3 drolando users 4096 2016-12-27 12:40 lib/
drwxr-xr-x 2 drolando users 4096 2016-12-27 12:40 libexec/
drwxr-xr-x 2 drolando users 4096 2016-12-27 12:34 lib_pypy/
drwxr-xr-x 3 drolando users 4096 2016-12-27 12:34 lib-python/
drwxr-xr-x 2 drolando users 4096 2016-12-27 12:40 sbin/
drwxr-xr-x 8 drolando users 4096 2016-12-27 12:40 site-packages/
```

AFAIK packaging header files is not useful since python won't need / use them but will only look for .so files.